### PR TITLE
docs: Update repository URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ mcp-prompt-server/
 
 1.  Clone the repository:
     ```bash
-    git clone <repository_url>
+    git clone https://github.com/xiiizoux/mcp-prompt-server.git
     cd mcp-prompt-server
     ```
 2.  Install dependencies:


### PR DESCRIPTION
Replaces the placeholder <repository_url> with the specific GitHub repository URL in the installation instructions.